### PR TITLE
[REVIEW] Prevent more vertical code alignment cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ readable code.
       calc_something_else
     end
 
-    # good - it's apparent what's going on
+    # bad - vertical aligning indent
     kind = case year
            when 1850..1889 then 'Blues'
            when 1890..1909 then 'Ragtime'
@@ -423,7 +423,7 @@ readable code.
           body: source.text)
     end
 
-    # good
+    # bad (vertical aligning indent)
     def send_mail(source)
       Mailer.deliver(to: 'bob@example.com',
                      from: 'us@example.com',


### PR DESCRIPTION
See [wikipedia arguments against vertical code alignment](http://en.wikipedia.org/w/index.php?title=Programming_style&
oldid=592550160#Vertical_alignment)
### Short version:

changing the name of `kind` or (more likely) the method `send_mail` causes for larger patches then needed when using normal indent. It is comparable to:

``` ruby
let(:foo)      { 'foo' }
let(:bar)      { 'bar' }     
let(:spacious) { 'space' }
```

 then deciding `let(:spacious)` should be renamed to `let(:space)` and having to remove 3 spaces from 2 unrelated lines.

Different, but the same result:

``` ruby
# BAD
  calculate_the_thing(thing,
                      do: :stuff,
                      and: :more_stuff)


# method name change
+ parse_and_calculate_the_thing(thing             # this line is updated
+                               do: :stuff,       # and this one  :-(
+                               and: :more_stuff) # and this one >:-[
```

``` ruby
# GOOD
  calculate_the_thing(
    thing,
    do: :stuff,
    and: :more_stuff
  )


# smallest change
+ parse_and_calculate_the_thing( # this line is updated
    thing
    do: :stuff,
    and: :more_stuff
  )
```
